### PR TITLE
Update to version 2.2.12 with critical fixes for Action Scheduler integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## ⚙️ Changelog
 
+### 2.2.12 - Action Scheduler Missing Functions.php Fix
+
+🛠️ **Critical Fix**: Resolved Action Scheduler initialization error requiring missing functions.php file
+
+#### 🔧 Bug Fixes
+- **📁 Functions.php Requirements**: Fixed "Failed to open stream: No such file or directory" error for functions.php
+- **🏗️ Action Scheduler Integration**: Prevented ActionScheduler::init() calls when another plugin provides Action Scheduler
+- **🔧 Initialization Logic**: Enhanced logic to avoid calling ActionScheduler::init() for externally provided instances
+- **📦 Plugin Compatibility**: Improved compatibility with plugins like multisite-exporter that bundle Action Scheduler
+
+#### 🛡️ Defensive Programming
+- **🎯 Smart Detection**: Only initialize our bundled Action Scheduler when no other version is available
+- **📋 File Creation**: Automatically create minimal functions.php file when initializing our bundled Action Scheduler
+- **⚡ Early Exit Strategy**: Return early when Action Scheduler is provided by another plugin
+- **🔍 Comprehensive Checks**: Enhanced detection for function_exists(), class_exists(), and ActionScheduler_Versions
+
+#### 💡 Technical Improvements
+- **🏛️ Clean Architecture**: Removed unnecessary ActionScheduler::init() calls in activation hook
+- **🔐 Safe Initialization**: Only call ActionScheduler::init() when we load our own bundled version
+- **📈 Error Prevention**: Prevents fatal errors caused by Action Scheduler expecting functions.php files
+- **🛡️ Multi-Plugin Compatibility**: Better coexistence with other plugins that bundle Action Scheduler
+
 ### 2.2.11 - Enhanced Action Scheduler Conflict Prevention
 
 🛡️ **Comprehensive Conflict Resolution**: Multi-level defensive programming to prevent Action Scheduler conflicts

--- a/dio-cron.php
+++ b/dio-cron.php
@@ -3,7 +3,7 @@
  * Plugin Name: DIO Cron
  * Plugin URI: https://github.com/soderlind/dio-cron
  * Description: Run wp-cron on all public sites in a multisite network with Action Scheduler integration, security token authentication, and comprehensive network admin interface.
- * Version: 2.2.11
+ * Version: 2.2.12
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron, action-scheduler, admin-interface, security
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 2.2.11
+Stable tag: 2.2.12
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -276,6 +276,15 @@ DIO Cron includes detailed logging for debugging wp-cron triggers, but this feat
 1. No screenshots available.
 
 == Changelog ==
+
+= 2.2.12 =
+* **Critical Bug Fix**: Resolved "Failed to open stream: No such file or directory" error for missing functions.php file
+* **Action Scheduler Integration**: Fixed ActionScheduler::init() calls when another plugin provides Action Scheduler  
+* **Plugin Compatibility**: Enhanced compatibility with plugins like multisite-exporter that bundle Action Scheduler
+* **Defensive Programming**: Only initialize bundled Action Scheduler when no other version is available
+* **Automatic File Creation**: Creates minimal functions.php file when initializing our bundled Action Scheduler
+* **Smart Detection**: Improved logic to avoid calling ActionScheduler::init() for externally provided instances
+* **Error Prevention**: Prevents fatal errors caused by Action Scheduler expecting functions.php files
 
 = 2.2.11 =
 * **Enhanced Action Scheduler Conflict Prevention**: Comprehensive multi-level checks to prevent function redeclaration errors


### PR DESCRIPTION
…

- Resolved "Failed to open stream: No such file or directory" error for missing functions.php file
- Enhanced logic to prevent ActionScheduler::init() calls when another plugin provides Action Scheduler
- Improved compatibility with plugins that bundle Action Scheduler, such as multisite-exporter
- Implemented smart detection to only initialize bundled Action Scheduler when no other version is available
- Automatically create a minimal functions.php file during initialization to prevent fatal errors
- Removed unnecessary ActionScheduler::init() calls in activation hook for cleaner architecture