### PR TITLE
Refactor namespace from `Soderlind\Multisite\Cron` to `Soderlind\Multisite\DioCron`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## ⚙️ Changelog
 
+### 2.2.13 - Namespace Refactoring
+
+🏗️ **Code Organization**: Updated namespace from `Soderlind\Multisite\Cron` to `Soderlind\Multisite\DioCron`
+
+#### 🔧 Namespace Updates
+- **📦 Consistent Naming**: Changed namespace to match plugin name `DioCron` for better code organization
+- **🏛️ Code Structure**: Updated all class files to use new `Soderlind\Multisite\DioCron` namespace
+- **🔄 Reference Updates**: Updated all namespace references across plugin files including uninstall script
+- **📋 File Coverage**: Updated namespace in main plugin file, all class files, and utility scripts
+
+#### 💡 Technical Improvements
+- **🎯 Better Organization**: More logical namespace structure that reflects plugin naming
+- **🔐 Code Consistency**: Consistent namespace usage across entire codebase
+- **📈 Maintainability**: Improved code organization for future development
+- **🛡️ Quality Assurance**: All syntax checks passed after namespace changes
+
 ### 2.2.12 - Action Scheduler Missing Functions.php Fix
 
 🛠️ **Critical Fix**: Resolved Action Scheduler initialization error requiring missing functions.php file

--- a/dio-cron.php
+++ b/dio-cron.php
@@ -3,7 +3,7 @@
  * Plugin Name: DIO Cron
  * Plugin URI: https://github.com/soderlind/dio-cron
  * Description: Run wp-cron on all public sites in a multisite network with Action Scheduler integration, security token authentication, and comprehensive network admin interface.
- * Version: 2.2.12
+ * Version: 2.2.13
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+
@@ -18,7 +18,7 @@
  * @license     GPL-2.0+
  */
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 // Prevent direct access.
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -5,7 +5,7 @@
  * @package DIO_Cron
  */
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -460,8 +460,8 @@ class DIO_Cron_Admin {
 					</p>
 					<p>
 						<code style="background: #f1f1f1; padding: 4px 8px; font-family: 'Courier New', monospace;">
-																																																																																																																						define( 'DISABLE_WP_CRON', true );
-																																																																																																																					</code>
+																																																																																																																									define( 'DISABLE_WP_CRON', true );
+																																																																																																																								</code>
 					</p>
 					<p>
 						<strong><?php esc_html_e( 'Important:', 'dio-cron' ); ?></strong>
@@ -676,8 +676,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																															<?php echo esc_url( home_url( '/dio-cron?token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																														</code>
+																																																																																																		<?php echo esc_url( home_url( '/dio-cron?token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																	</code>
 						<?php endif; ?>
 
 						<p><strong><?php esc_html_e( 'Legacy Mode:', 'dio-cron' ); ?></strong></p>
@@ -688,8 +688,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																															<?php echo esc_url( home_url( '/dio-cron?immediate=1&token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																														</code>
+																																																																																																		<?php echo esc_url( home_url( '/dio-cron?immediate=1&token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																	</code>
 						<?php endif; ?>
 
 						<p><strong><?php esc_html_e( 'GitHub Actions:', 'dio-cron' ); ?></strong></p>
@@ -700,8 +700,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																															<?php echo esc_url( home_url( '/dio-cron?ga&token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																														</code>
+																																																																																																		<?php echo esc_url( home_url( '/dio-cron?ga&token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																	</code>
 						<?php endif; ?>
 					</div>
 				</div>

--- a/includes/class-dio-cron.php
+++ b/includes/class-dio-cron.php
@@ -5,7 +5,7 @@
  * @package DIO_Cron
  */
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -21,7 +21,7 @@ class DIO_Cron {
 	 *
 	 * @var string VERSION Plugin version
 	 */
-	const VERSION = '2.2.12';    /**
+	const VERSION = '2.2.13';    /**
 			* Instance of the queue manager
 			*
 			* @var DIO_Cron_Queue_Manager

--- a/includes/class-queue-manager.php
+++ b/includes/class-queue-manager.php
@@ -5,7 +5,7 @@
  * @package DIO_Cron
  */
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -89,7 +89,7 @@ class DIO_Cron_Queue_Manager {
 			return DIO_Cron_Utilities::create_action_scheduler_error();
 		}
 
-		$site_data = [
+		$site_data = [ 
 			'site_id'  => $site->blog_id,
 			'site_url' => $site->siteurl,
 		];
@@ -178,7 +178,7 @@ class DIO_Cron_Queue_Manager {
 			DIO_Cron_Utilities::get_action_scheduler_query_args( DIO_Cron_Utilities::PROCESS_SITE_HOOK, 'failed', 10 )
 		);
 
-		return [
+		return [ 
 			'pending'        => count( $pending ),
 			'in_progress'    => count( $in_progress ),
 			'failed'         => count( $failed ),

--- a/includes/class-site-processor.php
+++ b/includes/class-site-processor.php
@@ -9,7 +9,7 @@
 
 // phpcs:disable WordPress.Files.FileName.InvalidClassFileName
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -123,7 +123,7 @@ class DIO_Cron_Site_Processor {
 			sprintf(
 				'DIO Cron Success: Site %s completed - Response: %d (%.2fs)',
 				$site_url,
-				$result['response_code'] ?? 'N/A',
+				$result[ 'response_code' ] ?? 'N/A',
 				$execution_time
 			)
 		);
@@ -151,11 +151,11 @@ class DIO_Cron_Site_Processor {
 			)
 		);
 
-		$args = [
+		$args = [ 
 			'blocking'  => true,  // We want to wait for the response in queued processing.
 			'sslverify' => false,
 			'timeout'   => $timeout,
-			'headers'   => [
+			'headers'   => [ 
 				'User-Agent' => 'DIO-Cron/' . DIO_Cron::VERSION,
 			],
 		];
@@ -210,7 +210,7 @@ class DIO_Cron_Site_Processor {
 
 		// Consider anything in the 200 range as success.
 		if ( $response_code >= 200 && $response_code < 300 ) {
-			return [
+			return [ 
 				'success'        => true,
 				'response_code'  => $response_code,
 				'site_url'       => $site_url,
@@ -236,7 +236,7 @@ class DIO_Cron_Site_Processor {
 				esc_html__( 'HTTP %d: Cron request failed', 'dio-cron' ),
 				intval( $response_code )
 			),
-			[
+			[ 
 				'response_code'  => $response_code,
 				'execution_time' => $exec_time,
 				'timeout_used'   => $timeout,
@@ -272,7 +272,7 @@ class DIO_Cron_Site_Processor {
 	 */
 	public function process_sites_batch( $sites ) {
 		if ( empty( $sites ) ) {
-			return [
+			return [ 
 				'success'   => false,
 				'message'   => esc_html__( 'No sites provided for processing', 'dio-cron' ),
 				'processed' => 0,
@@ -310,7 +310,7 @@ class DIO_Cron_Site_Processor {
 		$end_time       = microtime( true );
 		$execution_time = number_format( $end_time - $start_time, 2 );
 
-		return [
+		return [ 
 			'success'        => empty( $errors ),
 			'message'        => empty( $errors ) ?
 				sprintf(
@@ -344,7 +344,7 @@ class DIO_Cron_Site_Processor {
 	 */
 	public function get_processing_stats() {
 		if ( ! DIO_Cron_Utilities::is_action_scheduler_available() ) {
-			return [
+			return [ 
 				'error' => 'Action Scheduler is not available',
 			];
 		}
@@ -375,7 +375,7 @@ class DIO_Cron_Site_Processor {
 		$today_end          = strtotime( 'tomorrow midnight', $current_local_time ) - 1;
 		$wp_current_time    = current_time( 'Y-m-d H:i:s' );
 
-		return [
+		return [ 
 			'timezone'              => $wp_timezone,
 			'current_local_time'    => $current_local_time,
 			'current_time_readable' => $wp_current_time,
@@ -397,7 +397,7 @@ class DIO_Cron_Site_Processor {
 		$total_today  = $completed_count + $failed_count;
 		$success_rate = $total_today > 0 ? ( $completed_count / $total_today ) * 100 : 0;
 
-		return [
+		return [ 
 			'completed_today' => $completed_count,
 			'failed_today'    => $failed_count,
 			'success_rate'    => $success_rate,
@@ -416,28 +416,28 @@ class DIO_Cron_Site_Processor {
 	 */
 	private function format_stats_response( $stats, $date_info, $method_used, $additional_debug = [] ) {
 		$debug_info = array_merge(
-			[
-				'current_time'          => $date_info['current_local_time'],
-				'current_time_readable' => $date_info['current_time_readable'],
-				'today_start'           => $date_info['today_start'],
-				'today_end'             => $date_info['today_end'],
-				'today_start_readable'  => $date_info['today_start_readable'],
-				'today_end_readable'    => $date_info['today_end_readable'],
-				'timezone'              => $date_info['timezone'],
-				'total_completed'       => $stats['completed_today'],
-				'total_failed'          => $stats['failed_today'],
-				'filtered_completed'    => $stats['completed_today'],
-				'filtered_failed'       => $stats['failed_today'],
+			[ 
+				'current_time'          => $date_info[ 'current_local_time' ],
+				'current_time_readable' => $date_info[ 'current_time_readable' ],
+				'today_start'           => $date_info[ 'today_start' ],
+				'today_end'             => $date_info[ 'today_end' ],
+				'today_start_readable'  => $date_info[ 'today_start_readable' ],
+				'today_end_readable'    => $date_info[ 'today_end_readable' ],
+				'timezone'              => $date_info[ 'timezone' ],
+				'total_completed'       => $stats[ 'completed_today' ],
+				'total_failed'          => $stats[ 'failed_today' ],
+				'filtered_completed'    => $stats[ 'completed_today' ],
+				'filtered_failed'       => $stats[ 'failed_today' ],
 				'method_used'           => $method_used,
 				'sample_action_dates'   => [],
 			],
 			$additional_debug
 		);
 
-		return [
-			'completed_today' => $stats['completed_today'],
-			'failed_today'    => $stats['failed_today'],
-			'success_rate'    => $stats['success_rate'],
+		return [ 
+			'completed_today' => $stats[ 'completed_today' ],
+			'failed_today'    => $stats[ 'failed_today' ],
+			'success_rate'    => $stats[ 'success_rate' ],
 			'debug_info'      => $debug_info,
 		];
 	}
@@ -449,8 +449,8 @@ class DIO_Cron_Site_Processor {
 	 * @return array|null
 	 */
 	private function get_stats_via_direct_query( $date_info ) {
-		$completed_count = $this->count_actions_fast( 'complete', $date_info['today_start'], $date_info['today_end'] );
-		$failed_count    = $this->count_actions_fast( 'failed', $date_info['today_start'], $date_info['today_end'] );
+		$completed_count = $this->count_actions_fast( 'complete', $date_info[ 'today_start' ], $date_info[ 'today_end' ] );
+		$failed_count    = $this->count_actions_fast( 'failed', $date_info[ 'today_start' ], $date_info[ 'today_end' ] );
 
 		// If counts are non-zero (or zero but valid), return stats directly.
 		if ( null !== $completed_count && null !== $failed_count ) {
@@ -470,7 +470,7 @@ class DIO_Cron_Site_Processor {
 	private function get_stats_via_action_scheduler_api( $date_info ) {
 		// Get all completed and failed actions.
 		$completed_all = as_get_scheduled_actions(
-			[
+			[ 
 				'hook'     => 'dio_cron_process_site',
 				'status'   => 'complete',
 				'group'    => 'dio-cron',
@@ -479,7 +479,7 @@ class DIO_Cron_Site_Processor {
 		);
 
 		$failed_all = as_get_scheduled_actions(
-			[
+			[ 
 				'hook'     => 'dio_cron_process_site',
 				'status'   => 'failed',
 				'group'    => 'dio-cron',
@@ -498,19 +498,19 @@ class DIO_Cron_Site_Processor {
 		$stats = $this->calculate_stats( $completed_count, $failed_count );
 
 		// If we still don't have any data, try a simpler approach.
-		if ( 0 === $stats['total_today'] ) {
+		if ( 0 === $stats[ 'total_today' ] ) {
 			$stats = $this->get_recent_stats_fallback( $date_info );
 		}
 
-		$additional_debug = [
+		$additional_debug = [ 
 			'total_completed'     => count( $completed_all ),
 			'total_failed'        => count( $failed_all ),
-			'method_used'         => 0 === $stats['total_today'] ? 'fallback' : 'fallback_manual_filter',
+			'method_used'         => 0 === $stats[ 'total_today' ] ? 'fallback' : 'fallback_manual_filter',
 			'sample_action_dates' => $this->get_sample_action_dates( $completed_all, $failed_all ),
 			'all_action_dates'    => array_slice( $debug_dates, 0, 10 ), // First 10 for debugging.
 		];
 
-		return $this->format_stats_response( $stats, $date_info, $additional_debug['method_used'], $additional_debug );
+		return $this->format_stats_response( $stats, $date_info, $additional_debug[ 'method_used' ], $additional_debug );
 	}
 
 	/**
@@ -527,13 +527,13 @@ class DIO_Cron_Site_Processor {
 
 		foreach ( $actions as $action ) {
 			$action_date   = $this->get_action_date( $action );
-			$debug_dates[] = [
+			$debug_dates[] = [ 
 				'type'     => $type,
 				'date'     => $action_date,
 				'readable' => $action_date ? wp_date( 'Y-m-d H:i:s', $action_date ) : 'null',
-				'in_range' => $action_date && $action_date >= $date_info['today_start'] && $action_date <= $date_info['today_end'],
+				'in_range' => $action_date && $action_date >= $date_info[ 'today_start' ] && $action_date <= $date_info[ 'today_end' ],
 			];
-			if ( $action_date && $action_date >= $date_info['today_start'] && $action_date <= $date_info['today_end'] ) {
+			if ( $action_date && $action_date >= $date_info[ 'today_start' ] && $action_date <= $date_info[ 'today_end' ] ) {
 				++$count;
 			}
 		}
@@ -550,7 +550,7 @@ class DIO_Cron_Site_Processor {
 	private function get_recent_stats_fallback( $date_info ) {
 		// Get recent actions without date filtering.
 		$recent_completed = as_get_scheduled_actions(
-			[
+			[ 
 				'hook'     => 'dio_cron_process_site',
 				'status'   => 'complete',
 				'group'    => 'dio-cron',
@@ -559,7 +559,7 @@ class DIO_Cron_Site_Processor {
 		);
 
 		$recent_failed = as_get_scheduled_actions(
-			[
+			[ 
 				'hook'     => 'dio_cron_process_site',
 				'status'   => 'failed',
 				'group'    => 'dio-cron',
@@ -573,14 +573,14 @@ class DIO_Cron_Site_Processor {
 		// Count recent actions from today.
 		foreach ( $recent_completed as $action ) {
 			$action_date = $this->get_action_date( $action );
-			if ( $action_date && $action_date >= $date_info['today_start'] ) {
+			if ( $action_date && $action_date >= $date_info[ 'today_start' ] ) {
 				++$completed_count;
 			}
 		}
 
 		foreach ( $recent_failed as $action ) {
 			$action_date = $this->get_action_date( $action );
-			if ( $action_date && $action_date >= $date_info['today_start'] ) {
+			if ( $action_date && $action_date >= $date_info[ 'today_start' ] ) {
 				++$failed_count;
 			}
 		}
@@ -679,7 +679,7 @@ class DIO_Cron_Site_Processor {
 			}
 			$date = $this->get_action_date( $action );
 			if ( $date ) {
-				$samples['completed'][] = [
+				$samples[ 'completed' ][] = [ 
 					'timestamp'   => $date,
 					'readable'    => date_i18n( 'Y-m-d H:i:s', $date ),
 					'object_type' => get_class( $action ),
@@ -696,7 +696,7 @@ class DIO_Cron_Site_Processor {
 			}
 			$date = $this->get_action_date( $action );
 			if ( $date ) {
-				$samples['failed'][] = [
+				$samples[ 'failed' ][] = [ 
 					'timestamp'   => $date,
 					'readable'    => date_i18n( 'Y-m-d H:i:s', $date ),
 					'object_type' => get_class( $action ),

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -5,7 +5,7 @@
  * @package DIO_Cron
  */
 
-namespace Soderlind\Multisite\Cron;
+namespace Soderlind\Multisite\DioCron;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -25,15 +25,15 @@ class DIO_Cron_Utilities {
 		$key   = 'dio_cron_network_stats';
 		$stats = get_site_transient( $key );
 		if ( ! is_array( $stats ) ) {
-			$stats = [
+			$stats = [ 
 				'total_runs'            => 0,
 				'last_run'              => 0,
 				'total_sites_processed' => 0,
 			];
 		}
-		++$stats['total_runs'];
-		$stats['last_run']               = time();
-		$stats['total_sites_processed'] += $sites_processed;
+		++$stats[ 'total_runs' ];
+		$stats[ 'last_run' ]              = time();
+		$stats[ 'total_sites_processed' ] += $sites_processed;
 		set_site_transient( $key, $stats, DAY_IN_SECONDS );
 	}
 
@@ -46,7 +46,7 @@ class DIO_Cron_Utilities {
 		$key   = 'dio_cron_network_stats';
 		$stats = get_site_transient( $key );
 		if ( ! is_array( $stats ) ) {
-			$stats = [
+			$stats = [ 
 				'total_runs'            => 0,
 				'last_run'              => 0,
 				'total_sites_processed' => 0,
@@ -70,7 +70,7 @@ class DIO_Cron_Utilities {
 	 * @return array
 	 */
 	public static function get_action_scheduler_error() {
-		return [
+		return [ 
 			'error' => esc_html__( 'Action Scheduler is not available', 'dio-cron' ),
 		];
 	}
@@ -102,7 +102,7 @@ class DIO_Cron_Utilities {
 	 * @return array
 	 */
 	public static function create_error_response( string $message, int $count = 0 ): array {
-		return [
+		return [ 
 			'success' => false,
 			'message' => $message,
 			'count'   => $count,
@@ -118,14 +118,14 @@ class DIO_Cron_Utilities {
 	 * @return array
 	 */
 	public static function create_success_response( string $message, int $count, ?float $execution_time = null ): array {
-		$response = [
+		$response = [ 
 			'success' => true,
 			'message' => $message,
 			'count'   => $count,
 		];
 
 		if ( null !== $execution_time ) {
-			$response['execution_time'] = $execution_time;
+			$response[ 'execution_time' ] = $execution_time;
 		}
 
 		return $response;
@@ -146,7 +146,7 @@ class DIO_Cron_Utilities {
 			return new \WP_Error( 'missing_site_url', esc_html__( 'Site URL is missing', 'dio-cron' ) );
 		}
 
-		$site_status_checks = [
+		$site_status_checks = [ 
 			'public'   => [ 'site_not_public', esc_html__( 'Site is not public', 'dio-cron' ) ],
 			'archived' => [ 'site_archived', esc_html__( 'Site is archived', 'dio-cron' ) ],
 			'deleted'  => [ 'site_deleted', esc_html__( 'Site is deleted', 'dio-cron' ) ],
@@ -157,11 +157,11 @@ class DIO_Cron_Utilities {
 			if ( 'public' === $property ) {
 				// Public should be 1 (true).
 				if ( isset( $site->$property ) && ! $site->$property ) {
-					return new \WP_Error( $error_info[0], $error_info[1] );
+					return new \WP_Error( $error_info[ 0 ], $error_info[ 1 ] );
 				}
 			} elseif ( isset( $site->$property ) && $site->$property ) {
 				// Other properties should be 0 (false) or not set.
-				return new \WP_Error( $error_info[0], $error_info[1] );
+				return new \WP_Error( $error_info[ 0 ], $error_info[ 1 ] );
 			}
 		}
 
@@ -205,7 +205,7 @@ class DIO_Cron_Utilities {
 	 * @return array
 	 */
 	public static function get_action_scheduler_query_args( string $hook, string $status, int $per_page = 25 ): array {
-		return [
+		return [ 
 			'hook'     => $hook,
 			'status'   => $status,
 			'group'    => 'dio-cron',
@@ -237,7 +237,7 @@ class DIO_Cron_Utilities {
 	 * @return array
 	 */
 	public static function create_no_sites_provided_error() {
-		return [
+		return [ 
 			'success'   => false,
 			'message'   => esc_html__( 'No sites provided for processing', 'dio-cron' ),
 			'processed' => 0,
@@ -252,7 +252,7 @@ class DIO_Cron_Utilities {
 	 * @return array|false Returns array with action and nonce, or false if invalid.
 	 */
 	public static function validate_admin_action( array $request ) {
-		if ( ! isset( $request['action'] ) ) {
+		if ( ! isset( $request[ 'action' ] ) ) {
 			return false;
 		}
 
@@ -260,14 +260,14 @@ class DIO_Cron_Utilities {
 			return false;
 		}
 
-		$action = sanitize_text_field( wp_unslash( $request['action'] ?? '' ) );
-		$nonce  = sanitize_text_field( wp_unslash( $request['_wpnonce'] ?? '' ) );
+		$action = sanitize_text_field( wp_unslash( $request[ 'action' ] ?? '' ) );
+		$nonce  = sanitize_text_field( wp_unslash( $request[ '_wpnonce' ] ?? '' ) );
 
 		if ( ! wp_verify_nonce( $nonce, 'dio_cron_admin' ) ) {
 			return false;
 		}
 
-		return [
+		return [ 
 			'action' => $action,
 			'nonce'  => $nonce,
 		];
@@ -298,7 +298,7 @@ class DIO_Cron_Utilities {
 	public static function add_admin_notice( string $type, string $message ): void {
 		add_action(
 			'admin_notices',
-			function () use ( $type, $message ) {
+			function () use ($type, $message) {
 				echo wp_kses_post( self::create_admin_notice_html( $type, $message ) );
 			}
 		);
@@ -340,7 +340,7 @@ class DIO_Cron_Utilities {
 
 		// Get all public sites in the network.
 		$sites = get_sites(
-			[
+			[ 
 				'public'   => 1,
 				'archived' => 0,
 				'deleted'  => 0,
@@ -439,7 +439,7 @@ class DIO_Cron_Utilities {
 		if ( function_exists( 'random_bytes' ) ) {
 			try {
 				return bin2hex( random_bytes( $length ) );
-			} catch ( \Exception $e ) {
+			} catch (\Exception $e) {
 				// Fall back to wp_generate_password if random_bytes fails.
 				// Intentionally empty - fallback is handled below.
 				unset( $e ); // Suppress unused variable warning.
@@ -471,14 +471,14 @@ class DIO_Cron_Utilities {
 		foreach ( $ip_keys as $key ) {
 			if ( ! empty( $_SERVER[ $key ] ) ) {
 				$ips = explode( ',', sanitize_text_field( wp_unslash( $_SERVER[ $key ] ) ) );
-				$ip  = trim( $ips[0] );
+				$ip  = trim( $ips[ 0 ] );
 				if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
 					return $ip;
 				}
 			}
 		}
 
-		return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+		return sanitize_text_field( wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ?? '' ) );
 	}
 
 	/**
@@ -507,7 +507,7 @@ class DIO_Cron_Utilities {
 		$current_time = time();
 		$requests     = array_filter(
 			$requests,
-			function ( $timestamp ) use ( $current_time, $time_window ) {
+			function ($timestamp) use ($current_time, $time_window) {
 				return ( $current_time - $timestamp ) < $time_window;
 			}
 		);
@@ -538,7 +538,7 @@ class DIO_Cron_Utilities {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Token-based API endpoint, not form processing
-		$provided_token = sanitize_text_field( wp_unslash( $_GET['token'] ?? $_POST['token'] ?? '' ) );
+		$provided_token = sanitize_text_field( wp_unslash( $_GET[ 'token' ] ?? $_POST[ 'token' ] ?? '' ) );
 
 		if ( empty( $provided_token ) ) {
 			return false; // No token provided - access denied.
@@ -565,10 +565,10 @@ class DIO_Cron_Utilities {
 			return false; // Ran too recently.
 		}
 		$lock = get_site_transient( $lock_key );
-		if ( $lock && isset( $lock['expires'] ) && $lock['expires'] > $now ) {
+		if ( $lock && isset( $lock[ 'expires' ] ) && $lock[ 'expires' ] > $now ) {
 			return false; // Already locked.
 		}
-		$lock_data = [
+		$lock_data = [ 
 			'server'    => gethostname(),
 			'pid'       => function_exists( 'getmypid' ) ? getmypid() : null,
 			'timestamp' => $now,
@@ -577,7 +577,7 @@ class DIO_Cron_Utilities {
 		set_site_transient( $lock_key, $lock_data, $timeout );
 		// Double-check we got the lock (race protection)
 		$verify = get_site_transient( $lock_key );
-		if ( $verify && $verify['timestamp'] === $now ) {
+		if ( $verify && $verify[ 'timestamp' ] === $now ) {
 			set_site_transient( $last_run_key, $now, $timeout );
 			return true;
 		}
@@ -600,7 +600,7 @@ class DIO_Cron_Utilities {
 	 */
 	public static function is_execution_locked() {
 		$lock = get_site_transient( 'dio_cron_execution_lock' );
-		return ( $lock && isset( $lock['expires'] ) && $lock['expires'] > time() );
+		return ( $lock && isset( $lock[ 'expires' ] ) && $lock[ 'expires' ] > time() );
 	}
 
 	/**
@@ -610,7 +610,7 @@ class DIO_Cron_Utilities {
 	 */
 	public static function get_execution_lock_info() {
 		$lock = get_site_transient( 'dio_cron_execution_lock' );
-		if ( $lock && isset( $lock['expires'] ) && $lock['expires'] > time() ) {
+		if ( $lock && isset( $lock[ 'expires' ] ) && $lock[ 'expires' ] > time() ) {
 			return $lock;
 		}
 		return null;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron, action-scheduler, admin-interface, security
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 2.2.12
+Stable tag: 2.2.13
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -276,6 +276,13 @@ DIO Cron includes detailed logging for debugging wp-cron triggers, but this feat
 1. No screenshots available.
 
 == Changelog ==
+
+= 2.2.13 =
+* **Namespace Refactoring**: Updated namespace from `Soderlind\Multisite\Cron` to `Soderlind\Multisite\DioCron` for better code organization
+* **Code Structure**: More logical namespace structure that reflects plugin naming convention
+* **Consistent Naming**: Updated all class files and references to use new DioCron namespace
+* **Quality Assurance**: All syntax checks passed and code organization improved
+* **Maintainability**: Enhanced code structure for future development and maintenance
 
 = 2.2.12 =
 * **Critical Bug Fix**: Resolved "Failed to open stream: No such file or directory" error for missing functions.php file

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,5 +14,5 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) && ! is_multisite() ) {
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-utilities.php';
 
 // Delete the options and transients set by the plugin.
-\Soderlind\Multisite\Cron\DIO_Cron_Utilities::clear_sites_cache();
+\Soderlind\Multisite\DioCron\DIO_Cron_Utilities::clear_sites_cache();
 flush_rewrite_rules();


### PR DESCRIPTION
This pull request focuses on refactoring the plugin's namespace for improved code organization and maintainability. The namespace has been updated throughout the codebase from `Soderlind\Multisite\Cron` to `Soderlind\Multisite\DioCron` to better align with the plugin's name. Additionally, all version numbers and documentation have been updated to reflect this change.

**Namespace Refactoring and Code Consistency:**

* Updated the namespace from `Soderlind\Multisite\Cron` to `Soderlind\Multisite\DioCron` in all class files, utility scripts, the main plugin file (`dio-cron.php`), and the uninstall script for consistent naming and better code organization. [[1]](diffhunk://#diff-499f950689f249c09c1d0ac975ec9c5ebfb06bd4235ee75d3b3dd623dcbc85b8L21-R21) [[2]](diffhunk://#diff-db3d12ea3f712106d1a00b2a24269b6b6cd61de9c05d1bb5d4bd5e4d45765505L8-R8) [[3]](diffhunk://#diff-2dbb7acc5ec7d7b4672443592cdc2df44ce04d433a701615b22bed52e83c4330L8-R8) [[4]](diffhunk://#diff-55a0cb4c43e956a585f2e2d83f496d6f8f5244d952a242fdcbe263f601efa59cL8-R8) [[5]](diffhunk://#diff-94fa236269f0f7654728477a3d61ba2ea8dc640bbd439c4ca6a6d67465a2bcf9L12-R12) [[6]](diffhunk://#diff-502fbd06fcc2429ac0fbcbe6847472f4d27fa31d34202d6699f191e527371a09L8-R8) [[7]](diffhunk://#diff-445f7da6877bb1dda2e959aa7e2bfe91657e7738aca6c2e4337238f612e7865bL17-R17)

* Updated all namespace references across the codebase, ensuring all classes and static method calls use the new namespace.

**Version and Documentation Updates:**

* Bumped plugin version from `2.2.12` to `2.2.13` in `dio-cron.php`, `includes/class-dio-cron.php`, and `readme.txt` to reflect the namespace refactoring release. [[1]](diffhunk://#diff-499f950689f249c09c1d0ac975ec9c5ebfb06bd4235ee75d3b3dd623dcbc85b8L6-R6) [[2]](diffhunk://#diff-2dbb7acc5ec7d7b4672443592cdc2df44ce04d433a701615b22bed52e83c4330L24-R24) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)

* Updated changelogs in both `CHANGELOG.md` and `readme.txt` to document the namespace change and its benefits for maintainability and code consistency. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R18) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R280-R286)