### PR TITLE
admin header warning fix in chan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## ⚙️ Changelog
 
+### 2.3.2 - Admin Header Warning Fix
+
+#### 🐛 Bug Fixes
+- Resolved "Cannot modify header information" warnings in the admin by removing early echo output from load-time hooks and gating debug comments behind `WP_DEBUG`. This ensures redirects (e.g., after POST and to Action Scheduler) work without header issues.
+
 ### 2.3.1 - Faster Stats Query
 
 #### ⚡ Performance

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ DIO Cron triggers WordPress cron jobs across all public sites in your multisite 
 - **Performance optimized** for large multisite networks
 - **Enhanced error handling** and recovery mechanisms
 
-Note: v2.3.1 improves the performance of daily stats by optimizing the underlying database query for large Action Scheduler tables.
+Notes:
+- v2.3.2 fixes an admin header warning by removing early output on load hooks and gating debug comments behind WP_DEBUG, ensuring redirects work reliably.
+- v2.3.1 improves the performance of daily stats by optimizing the underlying database query for large Action Scheduler tables.
 
 ## Quick Setup
 

--- a/dio-cron.php
+++ b/dio-cron.php
@@ -3,7 +3,7 @@
  * Plugin Name: DIO Cron
  * Plugin URI: https://github.com/soderlind/dio-cron
  * Description: Run wp-cron on all public sites in a multisite network with Action Scheduler integration, security token authentication, and comprehensive network admin interface.
- * Version: 2.3.1
+ * Version: 2.3.2
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -568,8 +568,8 @@ class DIO_Cron_Admin {
 					</p>
 					<p>
 						<code style="background: #f1f1f1; padding: 4px 8px; font-family: 'Courier New', monospace;">
-																																																																																																																																																				define( 'DISABLE_WP_CRON', true );
-																																																																																																																																																			</code>
+																																																																																																																																																							define( 'DISABLE_WP_CRON', true );
+																																																																																																																																																						</code>
 					</p>
 					<p>
 						<strong><?php esc_html_e( 'Important:', 'dio-cron' ); ?></strong>
@@ -783,8 +783,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																																																													<?php echo esc_url( home_url( '/dio-cron?token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																																																												</code>
+																																																																																																																																<?php echo esc_url( home_url( '/dio-cron?token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																																															</code>
 						<?php endif; ?>
 
 						<p><strong><?php esc_html_e( 'Legacy Mode:', 'dio-cron' ); ?></strong></p>
@@ -795,8 +795,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																																																													<?php echo esc_url( home_url( '/dio-cron?immediate=1&token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																																																												</code>
+																																																																																																																																<?php echo esc_url( home_url( '/dio-cron?immediate=1&token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																																															</code>
 						<?php endif; ?>
 
 						<p><strong><?php esc_html_e( 'GitHub Actions:', 'dio-cron' ); ?></strong></p>
@@ -807,8 +807,8 @@ class DIO_Cron_Admin {
 							</a>
 						<?php else : ?>
 							<code class="dio-cron-disabled-endpoint">
-																																																																																																																													<?php echo esc_url( home_url( '/dio-cron?ga&token=YOUR_TOKEN_HERE' ) ); ?>
-																																																																																																																												</code>
+																																																																																																																																<?php echo esc_url( home_url( '/dio-cron?ga&token=YOUR_TOKEN_HERE' ) ); ?>
+																																																																																																																															</code>
 						<?php endif; ?>
 					</div>
 				</div>
@@ -1014,11 +1014,8 @@ class DIO_Cron_Admin {
 			return;
 		}
 
-		// Debug: Add comment to see what screen we have.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Debug display only, not processing form data
-		if ( isset( $_GET[ 'page' ] ) && 'dio-cron-status' === $_GET[ 'page' ] ) {
-			echo '<!-- DIO Cron Contextual Help Debug - Screen ID: ' . esc_html( $screen->id ) . ' -->';
-		}
+		// Note: Avoid any direct echo here (runs on load-* hook) to prevent
+		// "headers already sent" warnings before potential redirects.
 
 		// Check if this is our DIO Cron page - be more flexible with screen ID matching.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Page identification only, not processing form data
@@ -1129,7 +1126,9 @@ class DIO_Cron_Admin {
 		}
 
 		$screen = get_current_screen();
-		if ( $screen ) {
+		// Only output debug comments when WP_DEBUG is enabled to minimize risk
+		// of accidental output interfering with redirects or headers.
+		if ( $screen && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			echo '<!-- DIO Cron Debug - Screen ID: ' . esc_html( $screen->id ) . ', Page Hook: ' . esc_html( $this->page_hook ) . ', Base: ' . esc_html( $screen->base ?? 'N/A' ) . ' -->';
 		}
 	}

--- a/includes/class-dio-cron.php
+++ b/includes/class-dio-cron.php
@@ -21,7 +21,7 @@ class DIO_Cron {
 	 *
 	 * @var string VERSION Plugin version
 	 */
-	const VERSION = '2.3.1';    /**
+	const VERSION = '2.3.2';    /**
 			* Instance of the queue manager
 			*
 			* @var DIO_Cron_Queue_Manager

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron, action-scheduler, admin-interface, security
 Requires at least: 6.5
 Tested up to: 6.8
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -297,6 +297,8 @@ DIO Cron includes detailed logging for debugging wp-cron triggers, but this feat
 == Changelog ==
 
 = 2.3.1 =
+* Fix: Resolved "Cannot modify header information" warnings by removing early echo output in load hooks and gating debug comments behind WP_DEBUG. Improves reliability of redirects in admin.
+
 * Performance: Optimized daily stats counting by replacing UNION-based query with an index-friendly DISTINCT join on logs. Reduces temporary table creation and speeds up counts for large Action Scheduler tables.
 * Internal: Minor refactors in stats path; no behavioral changes.
 


### PR DESCRIPTION
…gelog and README

- Updated version number in dio-cron.php and class-dio-cron.php to 2.3.2.
- Added changelog entry for version 2.3.2 detailing the resolution of "Cannot modify header information" warnings by removing early echo output and gating debug comments behind WP_DEBUG.
- Updated README notes to reflect the new version and the fix for admin header warnings.
- Changed stable tag in readme.txt to 2.3.2.